### PR TITLE
Support for multiple schema.org files

### DIFF
--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,18 +1,32 @@
 import parseIsoDuration from "parse-iso-duration";
 import { IRecipe, ISchemaRecipe } from "../interfaces";
 import humanizeDuration from "humanize-duration";
+import { HTMLElement } from "node-html-parser";
 
-export function parseRecipeToJSON(jsonLD: string): ISchemaRecipe | undefined {
-  if (!jsonLD) return undefined;
+export function parseJSONListToRecipe(
+  jsonList: HTMLElement[]
+): ISchemaRecipe | undefined {
+  if (!jsonList.length) return;
 
-  const json = JSON.parse(jsonLD);
+  const parsedJSONList: any[] = jsonList.map((jsonLD) =>
+    JSON.parse(jsonLD.rawText)
+  );
 
-  if (Array.isArray(json)) {
-    const recipe = json.find((v) => v["@type"].toLowerCase() === "recipe");
-    return recipe as ISchemaRecipe;
-  } else {
-    return json as ISchemaRecipe;
+  let recipe = parsedJSONList.find((v) => {
+    const type = v["@type"];
+    return Array.isArray(type)
+      ? type.some(
+          (item) => typeof item === "string" && item.toLowerCase() === "recipe"
+        )
+      : typeof type === "string" && type.toLowerCase() === "recipe";
+  });
+
+  // Fallback to the first parsed JSON Object
+  if (!recipe && parsedJSONList.length > 0) {
+    recipe = parsedJSONList[0];
   }
+
+  return recipe as ISchemaRecipe | undefined;
 }
 
 export function getAuthor(author: ISchemaRecipe["author"]): string | undefined {

--- a/src/helpers/parser.ts
+++ b/src/helpers/parser.ts
@@ -9,7 +9,7 @@ import {
   getUrl,
   parseInstructions,
   parseVideo,
-  parseRecipeToJSON,
+  parseJSONListToRecipe,
   getNutrition,
 } from "./helpers";
 
@@ -18,9 +18,11 @@ export function parseRecipe(html: string): IRecipe | string {
     const root = parse(html, {
       lowerCaseTagName: true,
     });
-    const jsonLD = root.querySelector("script[type='application/ld+json']");
-    if (!jsonLD) throw ERRORS.NO_JSON_LD;
-    const recipeRaw = parseRecipeToJSON(jsonLD.rawText);
+    const jsonList = root.querySelectorAll(
+      "script[type='application/ld+json']"
+    );
+    if (!jsonList) throw ERRORS.NO_JSON_LD;
+    const recipeRaw = parseJSONListToRecipe(jsonList);
     if (!recipeRaw) throw ERRORS.PARSING_ERROR;
     const author = getAuthor(recipeRaw.author);
     const datePublished = recipeRaw.datePublished


### PR DESCRIPTION
Hello,

I discovered that numerous websites embed multiple schema.org tags within their HTML. Previously, the parser only examined the first script tag. With the updated approach, every <script> tag containing JSON-LD is now evaluated, and the parser returns the first occurrence with `"@type": "Recipe"`.

This update also resolves issue #1. While the issue was not due to a fault in the parsing library but rather a peculiarity of the website, it is worth noting that schema.org typically allows only one `@type` to be specified.

